### PR TITLE
fix: 添加thinkjs依赖包

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "babel-preset-es2015-loose": "6.x.x",
     "babel-preset-react": "^6.3.13",
     "babel-preset-stage-0": "6.x.x",
+    "babel-preset-stage-1": "6.x.x",
     "classnames": "^2.2.3",
     "css-loader": "^0.23.1",
     "history": "^1.17.0",


### PR DESCRIPTION
compile里依赖了`stage-1`，导致直接`clone`下来编译报错