### PR TITLE
修复检测主题配置文件是否存在的bug

### DIFF
--- a/src/admin/controller/api/theme.js
+++ b/src/admin/controller/api/theme.js
@@ -9,9 +9,8 @@ const THEME_DIR = path.join(think.RESOURCE_PATH, 'theme');
 export default class extends Base {
   async getAction(){
     let themes = (await think.promisify(fs.readdir)(THEME_DIR));
-    let isExist = think.promisify(fs.exist);
     themes = themes.map(theme => ({id: theme, __info_file: path.join(THEME_DIR, theme, 'package.json')}))
-                   .filter(async theme => await isExist(theme.__info_file))
+                   .filter(theme => fs.existsSync(theme.__info_file))
                    .map(({id, __info_file}) => think.extend({id}, think.require(__info_file)));
     return this.success(themes);
   }


### PR DESCRIPTION
 - 我是用mac开发的，系统生成了.DS_Store文件导致了主题设置报错
- think.promisify(fs.exsist)不能正确检测是否存在，建议直接使用同步方法fs.existsSync