### PR TITLE
增加从Ghost博客导入功能

### DIFF
--- a/src/admin/controller/api/file.js
+++ b/src/admin/controller/api/file.js
@@ -351,12 +351,12 @@ export default class extends Base {
       //获取用户和标签
       const userSlug = authors.filter(author => author.id === item.author_id)[0].slug;
       const user = await this.model('user').where({ name: userSlug }).find();
-      const tag = postsTags.forEach(tag => {
-        let ret = []
+      let retTag = []
+      postsTags.forEach(tag => {
         if (tag.post_id === item.id) {
-          ret.push(tag.tag_id);
+          retTag.push(tag.tag_id);
         }
-        return ret;
+        return retTag;
       });
 
       const post = {
@@ -371,7 +371,7 @@ export default class extends Base {
         comment_num: 0,
         allow_comment: 1,
         is_public: Number(item.visibility === 'public'),
-        tag
+        tag: retTag
       };
       post.markdown_content = toMarkdown(post.content);
       await postModelInstance.addPost(post);

--- a/src/admin/controller/api/file.js
+++ b/src/admin/controller/api/file.js
@@ -28,6 +28,8 @@ export default class extends Base {
     /** 处理导入数据 **/
     if( this.post('importor') === 'wordpress' ) {
       return this.importFromWP();
+    } else if (this.post('importor') === 'ghost' ) {
+      return this.importFromGhost();
     }
 
     let file = this.file('file');
@@ -301,6 +303,107 @@ export default class extends Base {
     });
     Promise.all(pagesPromise);
     this.success(`共导入文章 ${(posts || []).length} 篇，页面 ${(pages || []).length} 页，分类 ${(categories || []).length} 个，标签 ${(tags || []).length} 个`);
+  }
+
+  async importFromGhost() {
+    const file = this.file('file');
+    if( !file ) { return this.fail('FILE_UPLOAD_ERROR'); }
+
+    const jsonObj = think.safeRequire(file.path);
+    if( !jsonObj ) { return this.fail('FILE_UPLOAD_ERROR'); } // 没有正确引入json文件内容，是否需要另外的提示语
+    const data = jsonObj.db[0].data;
+
+    // 导入用户
+    const [authors, userModelInstance] = [data.users, this.model('user')];
+    if(authors.length) {
+      const authorsPromise = authors.map(author => userModelInstance.addUser({
+        username: author.slug,
+        email: author.email,
+        display_name: author.name,
+        password: 'admin12345678',
+        type: 2, //默认导入用户都为编辑
+        status: 2, //默认导入用户都处于禁用状态
+      }, '127.0.0.1'));
+      await Promise.all(authorsPromise);
+    }
+
+    // 导入标签
+    const [tags, tagModelInstance] = [data.tags, this.model('tag')];
+    if(tags.length) {
+      const tagsPromise = tags.map(tag => tagModelInstance.addTag({
+        name: tag.name,
+        pathname: tag.slug
+      }));
+      await Promise.all(tagsPromise);
+    }
+
+    //导入文章
+    const postStatus = {
+      published: 3, //发布
+      draft: 0 //草稿
+    };
+    const [allPosts, postsTags, postModelInstance] = [
+      data.posts, data.posts_tags, this.model('post')
+    ];
+    const posts = allPosts.filter(item => item.page === 0);
+    const postsPromise = posts.map(async item => {
+      try{
+      //获取用户和标签
+      const userSlug = authors.filter(author => author.id === item.author_id)[0].slug;
+      const user = await this.model('user').where({ name: userSlug }).find();
+      const tag = postsTags.forEach(tag => {
+        let ret = []
+        if (tag.post_id === item.id) {
+          ret.push(tag.tag_id);
+        }
+        return ret;
+      });
+
+      const post = {
+        title: item.title,
+        pathname: item.slug,
+        content: item.html,
+        summary: item.html,
+        create_time: moment(new Date(item.created_at)).format('YYYY-MM-DD HH:mm:ss'),
+        update_time: moment(new Date(item.updated_at)).format('YYYY-MM-DD HH:mm:ss'),
+        status: postStatus[item.status] || 0,
+        user_id: user.id,
+        comment_num: 0,
+        allow_comment: 1,
+        is_public: Number(item.visibility === 'public'),
+        tag
+      };
+      post.markdown_content = toMarkdown(post.content);
+      await postModelInstance.addPost(post);
+      } catch(e) { console.log(e)}
+    });
+    Promise.all(postsPromise);
+
+    //导入页面
+    const pages = allPosts.filter(item => item.page === 1);
+    const pageModelInstance = this.model('page').setRelation('user');
+    const pagesPromise = pages.map(async item => {
+      const userSlug = authors.filter(author => author.id === item.author_id)[0].slug;
+      const user = await this.model('user').where({ name: userSlug }).find();
+
+      const page = {
+        title: item.title,
+        pathname: item.slug,
+        content: item.html,
+        summary: item.html,
+        create_time: moment(new Date(item.created_at)).format('YYYY-MM-DD HH:mm:ss'),
+        update_time: moment(new Date(item.updated_at)).format('YYYY-MM-DD HH:mm:ss'),
+        status: postStatus[item.status] || 0,
+        user_id: user.id,
+        comment_num: 0,
+        allow_comment: 1,
+        is_public: Number(item.visibility === 'public')
+      };
+      page.markdown_content = toMarkdown(page.content);
+      await pageModelInstance.addPost(page);
+    });
+    Promise.all(pagesPromise);
+    this.success(`共导入文章 ${(posts || []).length} 篇，页面 ${(pages || []).length} 页，标签 ${(tags || []).length} 个`);
   }
 
   formatArray(obj) {

--- a/www/static/css/admin.css
+++ b/www/static/css/admin.css
@@ -40,6 +40,7 @@ ul,ol{padding:0;list-style:none;}
 .form-group {overflow: hidden;}
 .options-2fa{max-width: 600px;}
 .options-2fa ul li {list-style-type: disc;margin-left: 18px;}
+.options-import{max-width: 600px;}
 
 #app,.fk{height: 100%;}
 /* 警告提示box */

--- a/www/static/src/admin/component/import.jsx
+++ b/www/static/src/admin/component/import.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import Base from 'base';
-import { Form, ValidatedInput, FileValidator } from 'react-bootstrap-validation';
+import { Radio, RadioGroup, Form, ValidatedInput, FileValidator } from 'react-bootstrap-validation';
 import firekylin from 'common/util/firekylin';
 
 import BreadCrumb from 'admin/component/breadcrumb';
@@ -9,14 +9,13 @@ import TipAction from 'common/action/tip';
 module.exports = class extends Base {
   state = {
     uploading: false,
-    uploadType: ''
+    uploadType: 'wordpress'
   };
-  handleValidSubmit(type, e) {
-    this.setState({ uploadType: type }); // 上传类型指定
+  handleValidSubmit(e) {
     this.setState({uploading: true});
     var form = new FormData();
     form.append('file', e.file[0]);
-    form.append('importor', type);
+    form.append('importor', this.state.uploadType);
     firekylin.upload(form).then(result => {
       TipAction.success(result.data);
       alert(result.data);
@@ -26,66 +25,76 @@ module.exports = class extends Base {
       this.setState({uploading: false});
     });
   }
+
   render(){
+    let uploadType = this.state.uploadType;
+    const radio = (
+      <RadioGroup
+          name='type'
+          value={uploadType}
+          validate={(value) => {
+            uploadType = value;
+            this.setState({ uploadType: uploadType });
+            return true;
+          }}
+      >
+        <Radio value='wordpress' label='WordPress' />
+        <Radio value='ghost' label='Ghost' />
+      </RadioGroup>
+    );
+    const wp = (
+      <div>
+        <p>请上传 WordPress 中导出的 .xml 文件</p>
+        <ValidatedInput
+            type="file"
+            name="file"
+            label="上传文件："
+            labelClassName="col-xs-2"
+            wrapperClassName="col-xs-10"
+            validate={files => {
+              if (FileValidator.isEmpty(files)) {
+                  return '请上传文件';
+              }
+              return true;
+            }}
+            accept="application/xml"
+        />
+      </div>
+    );
     const ghost = (
-      <div className="options-2fa" style={{borderTop: '1px solid #999', marginTop: '20px'}}>
-        <h3 style={{marginBottom: '20px'}}>上传 JSON 文件</h3>
+      <div>
         <p>请上传 Ghost 中导出的 .json 文件</p>
-        <Form
-            className="clearfix form-horizonal"
-            onValidSubmit={this.handleValidSubmit.bind(this, 'ghost')}
-        >
-          <ValidatedInput
-              type="file"
-              name="file"
-              label="上传文件："
-              labelClassName="col-xs-2"
-              wrapperClassName="col-xs-10"
-              validate={files => {
-                if (FileValidator.isEmpty(files)) {
-                    return '请上传文件';
-                }
-                return true;
-              }}
-              accept="application/json"
-          />
-          <button type="submit" className="btn btn-primary">
-            上传{this.state.uploadType === 'ghost' && this.state.uploading?'中...':''}
-          </button>
-        </Form>
+        <ValidatedInput
+            type="file"
+            name="file"
+            label="上传文件："
+            labelClassName="col-xs-2"
+            wrapperClassName="col-xs-10"
+            validate={files => {
+              if (FileValidator.isEmpty(files)) {
+                  return '请上传文件';
+              }
+              return true;
+            }}
+            accept="application/json"
+        />
       </div>
     );
     return (
       <div className="fk-content-wrap">
         <BreadCrumb {...this.props} />
         <div className="manage-container">
-          <div className="options-2fa">
-            <h3 style={{marginBottom: '20px'}}>上传 WXR 文件</h3>
-            <p>请上传 WordPress 中导出的 .xml 文件</p>
-            <Form
-                className="clearfix form-horizonal"
-                onValidSubmit={this.handleValidSubmit.bind(this, 'wordpress')}
-            >
-              <ValidatedInput
-                  type="file"
-                  name="file"
-                  label="上传文件："
-                  labelClassName="col-xs-2"
-                  wrapperClassName="col-xs-10"
-                  validate={files => {
-                    if (FileValidator.isEmpty(files)) {
-                        return '请上传文件';
-                    }
-                    return true;
-                  }}
-                  accept="application/xml"
-              />
-              <button type="submit" className="btn btn-primary">
-                上传{this.state.uploadType === 'wordpress' && this.state.uploading?'中...':''}
-              </button>
-            </Form>
-          </div>
-          { ghost }
+          <Form onValidSubmit={this.handleValidSubmit.bind(this)} className="clearfix options-import">
+            <div className="form-group">
+              <label>请选择导入的博客平台</label>
+              { radio }
+            </div>
+            { this.state.uploadType === 'wordpress' && wp }
+            { this.state.uploadType === 'ghost' && ghost }
+            <button type="submit" className="btn btn-primary">
+              上传{this.state.uploading?'中...':''}
+            </button>
+          </Form>
         </div>
       </div>
     );

--- a/www/static/src/admin/component/import.jsx
+++ b/www/static/src/admin/component/import.jsx
@@ -8,13 +8,15 @@ import TipAction from 'common/action/tip';
 
 module.exports = class extends Base {
   state = {
-    uploading: false
+    uploading: false,
+    uploadType: ''
   };
-  handleValidSubmit(e) {
+  handleValidSubmit(type, e) {
+    this.setState({ uploadType: type }); // 上传类型指定
     this.setState({uploading: true});
     var form = new FormData();
     form.append('file', e.file[0]);
-    form.append('importor', 'wordpress');
+    form.append('importor', type);
     firekylin.upload(form).then(result => {
       TipAction.success(result.data);
       alert(result.data);
@@ -25,6 +27,34 @@ module.exports = class extends Base {
     });
   }
   render(){
+    const ghost = (
+      <div className="options-2fa" style={{borderTop: '1px solid #999', marginTop: '20px'}}>
+        <h3 style={{marginBottom: '20px'}}>上传 JSON 文件</h3>
+        <p>请上传 Ghost 中导出的 .json 文件</p>
+        <Form
+            className="clearfix form-horizonal"
+            onValidSubmit={this.handleValidSubmit.bind(this, 'ghost')}
+        >
+          <ValidatedInput
+              type="file"
+              name="file"
+              label="上传文件："
+              labelClassName="col-xs-2"
+              wrapperClassName="col-xs-10"
+              validate={files => {
+                if (FileValidator.isEmpty(files)) {
+                    return '请上传文件';
+                }
+                return true;
+              }}
+              accept="application/json"
+          />
+          <button type="submit" className="btn btn-primary">
+            上传{this.state.uploadType === 'ghost' && this.state.uploading?'中...':''}
+          </button>
+        </Form>
+      </div>
+    );
     return (
       <div className="fk-content-wrap">
         <BreadCrumb {...this.props} />
@@ -34,7 +64,7 @@ module.exports = class extends Base {
             <p>请上传 WordPress 中导出的 .xml 文件</p>
             <Form
                 className="clearfix form-horizonal"
-                onValidSubmit={this.handleValidSubmit.bind(this)}
+                onValidSubmit={this.handleValidSubmit.bind(this, 'wordpress')}
             >
               <ValidatedInput
                   type="file"
@@ -50,9 +80,12 @@ module.exports = class extends Base {
                   }}
                   accept="application/xml"
               />
-              <button type="submit" className="btn btn-primary">上传{this.state.uploading?'中...':''}</button>
+              <button type="submit" className="btn btn-primary">
+                上传{this.state.uploadType === 'wordpress' && this.state.uploading?'中...':''}
+              </button>
             </Form>
           </div>
+          { ghost }
         </div>
       </div>
     );


### PR DESCRIPTION
### add import for ghost

@lizheming 之前说的导入功能（

研究了一下ghost导出的json格式，添加了这个功能，本机在dev和prod测试通过。node版本是6.9.1。

- 入口在导入设置，样式和导入wordPress一致，可能用radioGroup更好？
- 因为是json格式文件，没有引入新模块，直接利用了think.safeRequire
- Ghost博客测试了0.7+~0.8+的部分版本，高版本导出的json内容只多不少，应该没有字段错误的问题