### PR TITLE
fix 语法问题

### DIFF
--- a/src/admin/service/upload/remote.js
+++ b/src/admin/service/upload/remote.js
@@ -20,7 +20,7 @@ export default class extends Base {
       strictSSL: false,
       timeout: 1000,
       encoding: 'binary'
-    }).catch(() => throw Error("UPLOAD_URL_ERROR"));
+    }).catch(() => { throw Error("UPLOAD_URL_ERROR"); });
 
     if(result.headers["content-type"].indexOf('image') === -1) {
       throw Error('UPLOAD_TYPE_ERROR');


### PR DESCRIPTION
修复 箭头函数中使用 throw 语句，导致 Babel 无法编译（语法错误）。