### PR TITLE
update general image display

### DIFF
--- a/www/static/src/admin/component/options_general.jsx
+++ b/www/static/src/admin/component/options_general.jsx
@@ -72,13 +72,11 @@ module.exports = class extends Base {
       BtnProps.disabled = true;
     }
     const logoUrl = this.state.options.logo_url;
-    let logoExt;
+    let logoExt = `?m=${Date.now()}`;
     if (logoUrl.indexOf('data:image') > -1) {
       logoExt = '';
     } else if (logoUrl.indexOf('?') > -1) {
-      logoExt = `&?m=${Date.now()}`;
-    } else {
-      logoExt = `?m=${Date.now()}`;
+      logoExt = `&${logoExt}`;
     }
     return (
       <div className="fk-content-wrap">

--- a/www/static/src/admin/component/options_general.jsx
+++ b/www/static/src/admin/component/options_general.jsx
@@ -71,6 +71,27 @@ module.exports = class extends Base {
     if(this.state.submitting){
       BtnProps.disabled = true;
     }
+    const logoUrl = this.state.options.logo_url;
+    const uploadType = this.state.options.upload;
+    let logo;
+    if (!logoUrl) {
+      logo = null;
+    } else {
+      const style = {
+        width: '140px',
+        height: '140px',
+        display: 'block',
+        marginBottom: '10px',
+        backgroundImage: `url(${logoUrl}?m=${Date.now()})`,
+        backgroundSize: '100% 100%'
+      }
+      if (/^data:image/.test(logoUrl) || uploadType !== 'local') {
+        style.backgroundImage = `url(${logoUrl})`;
+      }
+      logo = (
+        <div className="logo-container" style={style}></div>
+      );
+    }
     return (
       <div className="fk-content-wrap">
         <BreadCrumb {...this.props} />
@@ -96,7 +117,7 @@ module.exports = class extends Base {
             </div>
             <div className="form-group">
               <label>LOGO 地址</label>
-              {this.state.options.logo_url ? <img src={this.state.options.logo_url + '?m=' + Date.now()} width="140px" height="140px" alt="logo" style={{display: 'block', marginBottom: '10px'}}/> : null}
+              { logo }
               <ValidatedInput
                 type="text"
                 name="logo_url"

--- a/www/static/src/admin/component/options_general.jsx
+++ b/www/static/src/admin/component/options_general.jsx
@@ -72,25 +72,13 @@ module.exports = class extends Base {
       BtnProps.disabled = true;
     }
     const logoUrl = this.state.options.logo_url;
-    const uploadType = this.state.options.upload;
-    let logo;
-    if (!logoUrl) {
-      logo = null;
+    let logoExt;
+    if (logoUrl.indexOf('data:image') > -1) {
+      logoExt = '';
+    } else if (logoUrl.indexOf('?') > -1) {
+      logoExt = `&?m=${Date.now()}`;
     } else {
-      const style = {
-        width: '140px',
-        height: '140px',
-        display: 'block',
-        marginBottom: '10px',
-        backgroundImage: `url(${logoUrl}?m=${Date.now()})`,
-        backgroundSize: '100% 100%'
-      }
-      if (/^data:image/.test(logoUrl) || uploadType !== 'local') {
-        style.backgroundImage = `url(${logoUrl})`;
-      }
-      logo = (
-        <div className="logo-container" style={style}></div>
-      );
+      logoExt = `?m=${Date.now()}`;
     }
     return (
       <div className="fk-content-wrap">
@@ -117,7 +105,7 @@ module.exports = class extends Base {
             </div>
             <div className="form-group">
               <label>LOGO 地址</label>
-              { logo }
+              {logoUrl ? <img src={logoUrl + logoExt} width="140px" height="140px" alt="logo" style={{display: 'block', marginBottom: '10px'}}/> : null}
               <ValidatedInput
                 type="text"
                 name="logo_url"


### PR DESCRIPTION
### 基本设置优化

最近在进行博客优化的过程中，发现有对logo图片的优化需求，有以下几种需求：

1：logo图片使用base64，基本设置页面使用img无法显示
2: logo使用cdn的处理功能，如七牛的?imageView2/0，又拍云的!xxx，img在带有?m=timestamp的情况下影响使用

改写后，基本设置的logo图采用背景图，并且在base64和使用cdn的情况下，使用不带时间戳的url，本地图片仍旧使用时间戳