### PR TITLE
修复feedFullText不为0时RSS显示问题

### DIFF
--- a/src/home/model/post.js
+++ b/src/home/model/post.js
@@ -117,7 +117,7 @@ export default class extends think.model.relation {
     if( this.feedFullText === '0' ) {
       field += 'summary,content';
     } else {
-      field = 'content';
+      field += 'content';
     }
 
     let data = await this.field(field).where(where).order('create_time DESC').setRelation(false).limit(10).select();


### PR DESCRIPTION
RSS页面缺失title,link,pubDate等字段，找了一下发现feedFullText不为0时field写错了导致的