### PR TITLE
遵循 PORT 环境变量

### DIFF
--- a/src/common/config/config.js
+++ b/src/common/config/config.js
@@ -9,6 +9,6 @@ if(think.isFile(portFile)){
  * config
  */
 export default {
-  port: port || 8360,
+  port: port || process.env.PORT || 8360,
   resource_reg: /^(static\/|theme\/|[^\/]+\.(?!js|html|xml)\w+$)/
 };


### PR DESCRIPTION
> Honor `PORT` environment variable as a secondary to `port` file.
> 在没有本地 `port` 文件时遵循 `PORT` 环境变量。

## 本地调试使用方法：
![image](https://cloud.githubusercontent.com/assets/5880908/24425408/2511ce68-13d2-11e7-94f3-114c85b6270a.png)


## 安装版使用方法：

1. **推荐：** 在 `pm2.json` 的 `env` block 里添加 `PORT` 如下：
```json
    "env": {
      "PORT": 8000
    }
```

2. 设置系统环境变量

Fixes #261.